### PR TITLE
chore: Refer to latest Ruby 3.0 with 2 positions in CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.0.2
+          - '3.0'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The setup-ruby Action will read those two positions, and find the latest release it knows about, that matches. So, this change hopes to reduce the maintenance needed for this configuration file.

(YAML: The value is quoted, in order to have it be presented in "name" directives etc as "3.0", not as "3".)